### PR TITLE
Adding links for companies, applications, mtl and resources

### DIFF
--- a/2012201.md
+++ b/2012201.md
@@ -7,3 +7,5 @@ Edward Kmett explains [at reddit](https://old.reddit.com/r/haskell/comments/fnpt
 > `transformers` provides the data types themselves and requires no real language extensions. e.g. `StateT s` lives here. `mtl` provides a set of classes for the individual effects. e.g. `MonadState` lives here. `mtl` sits atop `transformers`.
 
 > We split `mtl` from `transformers` to allow folks to experiment with different forms of class structures without having to change the actual data types used. (e.g. `monads-tf` uses type families rather than fundeps, and some of the effect system folks borrow the underlying data types.)
+
+* [mtl is Not a Monad Transformer Library](https://blog.jle.im/entry/mtl-is-not-a-monad-transformer-library.html)

--- a/2012407.md
+++ b/2012407.md
@@ -4,6 +4,10 @@ title: Challenges of learning Haskell
 
 Unlike many other languages Haskell has its own challenges when it comes to a beginner learning to use it for real-world projects.
 
+For example:
+
+* April, 2020: [Things software engineers trip up on when learning Haskell](https://williamyaoh.com/posts/2020-04-12-software-engineer-hangups.html)
+
 ## Proposed solutions
 
 * [2012406](z://boringhaskell)

--- a/2012502.md
+++ b/2012502.md
@@ -20,6 +20,7 @@ You have learned the basics of Haskell, and now want to begin using the language
 
 ## Unfinished resources 
 
+* [Haskell in Depth](https://www.manning.com/books/haskell-in-depth)
 * [Intermediate Haskell by Vlad & Artyom](https://intermediatehaskell.com/)
 * [Haskell Almanac](https://lorepub.com/product/cookbook)
 

--- a/2012504.md
+++ b/2012504.md
@@ -29,4 +29,5 @@ u/bravit [writes](https://old.reddit.com/r/haskell/comments/82p0de/haskell_books
 
 * [2012407](z://learning-challenges)
 * [What I Wish I Knew When Learning Haskell](http://dev.stephendiehl.com/hask/)
-
+* [argumatronic - For Beginners](https://argumatronic.com/posts/1970-01-01-beginners.html)
+* [Type Classes - The Haskell Phrasebook](https://typeclasses.com/phrasebook)

--- a/2014102.md
+++ b/2014102.md
@@ -4,5 +4,19 @@ title: Applications
 
 Applications written in Haskell
 
+* [Aura](https://github.com/aurapm/aura/) - A package manager for Arch Linux and its AUR
+* [CodeWorld](https://github.com/google/codeworld) - CodeWorld is an educational environment using Haskell
 * [2013501](z://json-cli)
-
+* [gifcurry](https://lettier.github.io/gifcurry/) - Your open source video to GIF maker built with Haskell
+* [Haskell-Poker](https://github.com/therewillbecode/haskell-poker) - A poker site built with Haskell
+* [hledger](http://hledger.org/) -  Friendly, robust, plain text accounting
+* [Komposition](https://owickstrom.github.io/komposition) - The video editor built for screencasters
+* [Matterhorn](https://github.com/matterhorn-chat/matterhorn) - A terminal client for the Mattermost chat system
+* [Movie-Monad](https://github.com/lettier/movie-monad) - A free and simple to use video player made with Haskell
+* [patat](https://github.com/jaspervdj/patat) - Terminal-based presentations using Pandoc
+* [postgrest](https://github.com/begriffs/postgrest) - REST API for any Postgres database
+* [PureScript](https://github.com/purescript/purescript) - A strongly-typed language that compiles to Javascript
+* [Project:m36](https://github.com/agentm/project-m36) - A relational algebra engine as inspired by the writings of Chris Date
+* [Taskell](https://taskell.app/) - Command-line Kanban board/task management
+* [termonad](https://github.com/cdepillabout/termonad) - A terminal emulator configurable in Haskell
+* [Tidal](https://github.com/tidalcycles/Tidal) - Language for live coding of pattern

--- a/2015301.md
+++ b/2015301.md
@@ -2,6 +2,5 @@
 title: Haskell in the Industry
 ---
 
-* [Towards Faster Iteration in Industrial Haskell](https://blog.sumtypeofway.com/posts/fast-iteration-with-haskell.html) -
-via [reddit](https://old.reddit.com/r/haskell/comments/g1ajqe/towards_faster_iteration_in_industrial_haskell/)
-
+* [Towards Faster Iteration in Industrial Haskell](https://blog.sumtypeofway.com/posts/fast-iteration-with-haskell.html) - via [reddit](https://old.reddit.com/r/haskell/comments/g1ajqe/towards_faster_iteration_in_industrial_haskell/)
+* [A list of companies that use Haskell](https://github.com/erkmos/haskell-companies)


### PR DESCRIPTION
I've grouped a few commits together and added more information regarding applications written in Haskell, learning resources, mtl vs transformers and companies using Haskell.